### PR TITLE
Properly send currency info to solo.com.hr

### DIFF
--- a/admin/class-request.php
+++ b/admin/class-request.php
@@ -263,7 +263,7 @@ class Request {
     if ( $solo_api_bill_type === 'ponuda' ) {
       $post_url .= '&jezik_ponude=' . $solo_api_languages . '&valuta_ponude=' . $solo_api_currency;
     } else {
-      $post_url .= '&jezik_racuna=' . $solo_api_languages;
+      $post_url .= '&jezik_racuna=' . $solo_api_languages . '&valuta_ponude=' . $solo_api_currency;
     }
 
     if ( $solo_api_currency !== '1' ) { // Only for foreign currency.

--- a/admin/class-request.php
+++ b/admin/class-request.php
@@ -263,7 +263,7 @@ class Request {
     if ( $solo_api_bill_type === 'ponuda' ) {
       $post_url .= '&jezik_ponude=' . $solo_api_languages . '&valuta_ponude=' . $solo_api_currency;
     } else {
-      $post_url .= '&jezik_racuna=' . $solo_api_languages . '&valuta_ponude=' . $solo_api_currency;
+      $post_url .= '&jezik_racuna=' . $solo_api_languages . '&valuta_racuna=' . $solo_api_currency;
     }
 
     if ( $solo_api_currency !== '1' ) { // Only for foreign currency.


### PR DESCRIPTION
Solo can issue a proper invoice in foregin currency. If USD or EUR is selected as a currency on a website, solo can create an invoice that converts USD/EUR to HRK on the day of invoice. For that it's essential that plugin send currency info to solo. Otherwise all items of the invoice end up being in HRK.