### PR TITLE
Remove manually included core stubs

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,6 @@ parameters:
     excludes_analyse:
         - src/Core/CompiledContainer.php
     bootstrapFiles:
-        - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
         - vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
         - vendor/php-stubs/woocommerce-stubs/woocommerce-packages-stubs.php
         - vendor/php-stubs/wordpress-globals/wordpress-globals.php


### PR DESCRIPTION
@dingo-d It is included in szepeviktor/phpstan-wordpress