### PR TITLE
Upgrade phpstan-wp-action

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -57,7 +57,7 @@ jobs:
           dependency-versions: 'highest'
 
       - name: Analyse code using phpstan
-        uses: dingo-d/phpstan-wp-action@v1
+        uses: dingo-d/phpstan-wp-action@master
 
   phpunit:
     name: PHPUnit on PHP ${{ matrix.php }}


### PR DESCRIPTION
@dingo-d Now meaningful reports are coming out: https://github.com/dingo-d/woo-solo-api/pull/101/files

Could you release v2 of phpstan-wp-action with Composer v2 and upgrade actions in this workflow?